### PR TITLE
Fix error text in IPv4 parser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -579,7 +579,7 @@ export class Address {
    */
   private static parseIPv4Address(input: string): Address {
     if (input.includes("%")) {
-      throw new Error(`Invalid IPv4 addressclea `);
+      throw new Error("Invalid IPv4 address");
     }
 
     const parts = input.split(".");


### PR DESCRIPTION
## Summary
- correct typo in IPv4 parsing error message

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683f549763ac832cb24c031519e902dd